### PR TITLE
Added attribute existence check on the event webhook data.

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -48,6 +48,17 @@ abstract class Event
     }
 
     /**
+     * Determine if an attribute exists on the webhook data.
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return isset($this->webhookData[$key]);
+    }
+
+    /**
      * Generates the event class name with the 'alert_name' attribute from
      * the data and fires the event with the data.
      *

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -24,6 +24,19 @@ class EventTest extends TestCase
     }
 
     /** @test */
+    public function it_can_check_if_payload_key_exists()
+    {
+        $event = new SubscriptionCreated([
+            'product_id' => 10,
+        ]);
+
+        $this->assertTrue(isset($event->product_id));
+        $this->assertFalse(empty($event->product_id));
+        $this->assertFalse(isset($event->dummy_key));
+        $this->assertTrue(empty($event->dummy_key));
+    }
+
+    /** @test */
     public function it_can_fire_an_event_based_on_the_action_name()
     {
         EventFacade::fake();


### PR DESCRIPTION
## Description

I've added a simple `__isset` method on the Event base class, so that users could check the value/existence of keys on the webhook payload data.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
